### PR TITLE
FixBugs:afterRender trigger EVENT_AFTER_RENDER

### DIFF
--- a/docs/guide-zh-CN/structure-views.md
+++ b/docs/guide-zh-CN/structure-views.md
@@ -637,7 +637,7 @@ $this->registerLinkTag([
 
 - [[yii\base\View::EVENT_BEFORE_RENDER|EVENT_BEFORE_RENDER]]: 在控制器渲染文件开始时触发，
   该事件可设置 [[yii\base\ViewEvent::isValid]] 为 false 取消视图渲染。
-- [[yii\base\View::EVENT_AFTER_RENDER|EVENT_AFTER_RENDER]]: 在布局中调用 [[yii\base\View::beginPage()]] 时触发，
+- [[yii\base\View::EVENT_AFTER_RENDER|EVENT_AFTER_RENDER]]: 在布局中调用 [[yii\base\View::afterRender()]] 时触发，
   该事件可获取[[yii\base\ViewEvent::output]]的渲染结果，
   可修改该属性来修改渲染结果。
 - [[yii\base\View::EVENT_BEGIN_PAGE|EVENT_BEGIN_PAGE]]: 在布局调用 [[yii\base\View::beginPage()]] 时触发；
@@ -691,7 +691,7 @@ class SiteController extends Controller
 ```
 
 现在如果你在`@app/views/site/pages`目录下创建名为 `about` 的视图，
-可通过如下rul显示该视图：
+可通过如下url显示该视图：
 
 ```
 http://localhost/index.php?r=site/page&view=about


### PR DESCRIPTION
ps：
#yii\base\View::afterRender()
    public function afterRender($viewFile, $params, &$output)
    {
        if ($this->hasEventHandlers(self::EVENT_AFTER_RENDER)) {
            $event = new ViewEvent([
                'viewFile' => $viewFile,
                'params' => $params,
                'output' => $output,
            ]);
            $this->trigger(self::EVENT_AFTER_RENDER, $event);
            $output = $event->output;
        }
    }

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
