### PR TITLE
Update helper-array.md

### DIFF
--- a/docs/guide-zh-CN/helper-array.md
+++ b/docs/guide-zh-CN/helper-array.md
@@ -260,7 +260,7 @@ $array = [
     ['id' => '123', 'name' => 'aaa', 'class' => 'x'],
     ['id' => '124', 'name' => 'bbb', 'class' => 'x'],
     ['id' => '345', 'name' => 'ccc', 'class' => 'y'],
-);
+];
 
 $result = ArrayHelper::map($array, 'id', 'name');
 // 结果是： 

--- a/docs/guide-zh-CN/helper-array.md
+++ b/docs/guide-zh-CN/helper-array.md
@@ -1,7 +1,7 @@
 数组助手类（ArrayHelper）
 ======================
 
-除了[PHP中丰富的数组函数集](http://php.net/manual/zh/book.array.php)，
+除了 [PHP 中丰富的数组函数集](http://php.net/manual/zh/book.array.php)，
 Yii 数组助手类提供了额外的静态方法，让你更高效地处理数组。
 
 
@@ -117,7 +117,7 @@ $type = ArrayHelper::remove($array, 'type');
 
 ## 检查键名的存在（Checking Existence of Keys） <span id="checking-existence-of-keys"></span>
 
-`ArrayHelper::keyExists` 工作原理和[array_key_exists](http://php.net/manual/en/function.array-key-exists.php)差不多，除了
+`ArrayHelper::keyExists` 工作原理和 [array_key_exists](http://php.net/manual/en/function.array-key-exists.php) 差不多，除了
 它还可支持大小写不敏感的键名比较，比如：
 
 ```php
@@ -136,7 +136,7 @@ if (!ArrayHelper::keyExists('username', $data1, false) || !ArrayHelper::keyExist
 
 ## 检索列（Retrieving Columns） <span id="retrieving-columns"></span>
 
-通常你要从多行数据或者多个对象构成的数组中获取某列的值，一个普通的例子是获取id值列表。
+通常你要从多行数据或者多个对象构成的数组中获取某列的值，一个普通的例子是获取 id 值列表。
 
 ```php
 $data = [
@@ -320,7 +320,7 @@ ArrayHelper::multisort($data, function($item) {
 `SORT_DESC` 之一。如果是按多个键名排序，你可以用一个数组为
 各个键指定不同的顺序。
 
-最后一个参数（译者注：第四个参数）是PHP的排序标识（sort flag），可使用的值和调用PHP
+最后一个参数（译者注：第四个参数）是PHP的排序标识（sort flag），可使用的值和调用 PHP
 [sort()](http://php.net/manual/zh/function.sort.php) 函数时传递的值一样。
 
 


### PR DESCRIPTION
一个demo中数组定义写法有误，将$array = [ ... ); 更正为 $array = [ ... ];

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
