### PR TITLE
Update db-active-record.md

### DIFF
--- a/docs/guide-zh-CN/db-active-record.md
+++ b/docs/guide-zh-CN/db-active-record.md
@@ -462,7 +462,7 @@ $post->updateCounters(['view_count' => 1]);
 
 Active Record 自动维护脏属性列表。 它保存所有属性的旧值，
 并其与最新的属性值进行比较，就是酱紫个道理。你可以调用 [[yii\db\ActiveRecord::getDirtyAttributes()]] 
-获取当前的脏属性。你也可以调用 [[yii\db\ActiveRecord::getDirtyAttributes()]] 
+获取当前的脏属性。你也可以调用 [[yii\db\ActiveRecord::markAttributeDirty()]] 
 将属性显式标记为脏。
 
 如果你有需要获取属性原先的值，你可以调用

--- a/docs/guide-zh-CN/db-active-record.md
+++ b/docs/guide-zh-CN/db-active-record.md
@@ -460,9 +460,9 @@ $post->updateCounters(['view_count' => 1]);
 刚刚保存到 DB 。请注意，无论如何 Active Record 都会执行数据验证
 不管有没有脏属性。
 
-Active Record 自动维护脏属性列表。 它保存所有属性的旧值，
-并其与最新的属性值进行比较，就是酱紫个道理。你可以调用 [[yii\db\ActiveRecord::getDirtyAttributes()]] 
-获取当前的脏属性。你也可以调用 [[yii\db\ActiveRecord::markAttributeDirty()]] 
+Active Record 自动维护脏属性列表。它保存所有属性的旧值，
+并其与最新的属性值进行比较。你可以调用 [[yii\db\ActiveRecord::getDirtyAttributes()]]
+获取当前的脏属性。你也可以调用 [[yii\db\ActiveRecord::markAttributeDirty()]]
 将属性显式标记为脏。
 
 如果你有需要获取属性原先的值，你可以调用


### PR DESCRIPTION
You can also call [[yii\db\ActiveRecord::markAttributeDirty()]] to explicitly mark an attribute as dirty.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | no
